### PR TITLE
Fix error handling

### DIFF
--- a/cococoLibrary/Converter.swift
+++ b/cococoLibrary/Converter.swift
@@ -12,7 +12,7 @@ import Foundation
 public class Converter {
 	
 	private let io = IO()
-	private let arrayWriteQueue = DispatchQueue(label: "write-queue", attributes: .concurrent)
+	private let arrayWriteQueue = DispatchQueue(label: "write-queue")
 	private let xmlEscaper = XMLEscaper()
 	
 	public init() {}
@@ -57,22 +57,18 @@ public class Converter {
 		}
 		
 		var finalOutput = Array<String?>(repeating: nil, count: fileList.count)
-		let group = DispatchGroup()
 		DispatchQueue.concurrentPerform(iterations: fileList.count) { (i) in
-			group.enter()
 			let filePath = String(fileList[i])
 			io.print("\(i + 1)/\(fileList.count) \(filePath)", to: .error)
 			do {
 				let output = try convertFile(filePath, archivePath: archivePath)
-				arrayWriteQueue.async(flags: .barrier) {
+				arrayWriteQueue.sync {
 					finalOutput[i] = output
-					group.leave()
 				}
 			} catch {
-				io.print("Conversion failed for: \(filePath)", to: .error)
+				io.print("Conversion failed for \(filePath): \(error)", to: .error)
 			}
 		}
-		group.wait()
         return finalOutput
 	}
 

--- a/cococoLibrary/Converter.swift
+++ b/cococoLibrary/Converter.swift
@@ -57,6 +57,7 @@ public class Converter {
 		}
 		
 		var finalOutput = Array<String?>(repeating: nil, count: fileList.count)
+		var lastError: Error?
 		DispatchQueue.concurrentPerform(iterations: fileList.count) { (i) in
 			let filePath = String(fileList[i])
 			io.print("\(i + 1)/\(fileList.count) \(filePath)", to: .error)
@@ -67,7 +68,11 @@ public class Converter {
 				}
 			} catch {
 				io.print("Conversion failed for \(filePath): \(error)", to: .error)
+				lastError = error
 			}
+		}
+		if let error = lastError {
+			throw error
 		}
         return finalOutput
 	}


### PR DESCRIPTION
- Remove dispatch group because an exception in `convertFile` would not leave the group. Instead of _also_ leaving the group in the catch block the need for the group could be replaced by using a serial queue for `arrayWriteQueue`  and dispatching sync.
- Report conversion errors instead of silently ignoring them